### PR TITLE
removed stale line from console.py docstring

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1925,7 +1925,6 @@ class Console:
             end (str, optional): String to write at end of print data. Defaults to "\\\\n".
             style (Union[str, Style], optional): A style to apply to output. Defaults to None.
             justify (str, optional): One of "left", "right", "center", or "full". Defaults to ``None``.
-            overflow (str, optional): Overflow method: "crop", "fold", or "ellipsis". Defaults to None.
             emoji (Optional[bool], optional): Enable emoji code, or ``None`` to use console default. Defaults to None.
             markup (Optional[bool], optional): Enable markup, or ``None`` to use console default. Defaults to None.
             highlight (Optional[bool], optional): Enable automatic highlighting, or ``None`` to use console default. Defaults to None.


### PR DESCRIPTION

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Description


Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

**removed one stale line from console.log docstring. overflow support is not there (would be cool tho). corrected docstring.**
